### PR TITLE
Release 0.2.0: sync packaging version and add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,39 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI when a GitHub Release is published.
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens or secrets required.
+# One-time setup on PyPI: add a trusted publisher for this project pointing at
+#   owner: grcarmenaty, repo: pymodal, workflow: publish-pypi.yml, environment: pypi
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    name: Build and publish distribution to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pymodal
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,29 @@
+import re
+from pathlib import Path
+
 import setuptools
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()
 
+# Single source of truth for the version: pymodal/__init__.py
+_init = Path(__file__).parent / "pymodal" / "__init__.py"
+version = re.search(
+    r'^__version__\s*=\s*["\']([^"\']+)["\']',
+    _init.read_text(encoding="utf-8"),
+    re.MULTILINE,
+).group(1)
+
 setuptools.setup(
     name="pymodal",
-    version="0.0.4",
+    version=version,
     author="Guillermo Reyes Carmenaty",
     author_email="grcarmenaty@gmail.com",
     description="Modal analysis data management, simulation and storage tool",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     url="https://github.com/grcarmenaty/pymodal",
-    download_url="https://github.com/grcarmenaty/pymodal/archive/0.0.4.tar.gz",
+    download_url="https://github.com/grcarmenaty/pymodal/archive/{}.tar.gz".format(version),
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary

Prepares pymodal `0.2.0` for publication to PyPI.

- **Version reconciled to `0.2.0`.** `setup.py` was stale at `0.0.4` (the last 2020 release) while `pymodal/__init__.py` already declared `0.2.0`. `setup.py` now reads `__version__` from `pymodal/__init__.py` as the single source of truth, so the packaging version and the in-package version can never drift again. `setup.py --version` now reports `0.2.0`.
- **README rendering.** Added `long_description_content_type="text/x-rst"` so the reStructuredText README renders on the PyPI project page.
- **Publish workflow.** Added `.github/workflows/publish-pypi.yml`, which builds the sdist + wheel and uploads to PyPI via **Trusted Publishing (OIDC)** — no API tokens or secrets — when a GitHub Release is published.

## Remaining steps to actually publish

1. **Merge this PR into `master`** — `release`-triggered workflows run from the default branch only, so the workflow must live on `master`.
2. **Configure Trusted Publishing on PyPI** (one-time): project `pymodal` → *Publishing* → add publisher with owner `grcarmenaty`, repo `pymodal`, workflow `publish-pypi.yml`, environment `pypi`.
3. **Create a GitHub Release tagged `0.2.0`** — publishing it triggers the workflow and uploads to PyPI.

https://claude.ai/code/session_01LtVg1BupJaj941RsW1AV1W

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtVg1BupJaj941RsW1AV1W)_